### PR TITLE
feat: Implementa flujo de Matrícula e Inscripción con comprobante PDF y pagos simulados

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "flowbite-react": "^0.10.2",
         "formik": "^2.4.5",
         "formik-mui": "^5.0.0-alpha.0",
+        "jspdf": "^3.0.3",
         "lodash": "^4.17.21",
         "prop-types": "^15.7.2",
         "react": "^18.2.0",
@@ -3379,6 +3380,12 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/phoenix": {
       "version": "1.6.6",
       "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
@@ -3390,6 +3397,13 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.26",
@@ -3437,6 +3451,13 @@
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -3700,6 +3721,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.19.tgz",
@@ -3836,6 +3867,26 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3954,6 +4005,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.46.0.tgz",
+      "integrity": "sha512-vDMm9B0xnqqZ8uSBpZ8sNtRtOdmfShrvT6h2TuQGLs0Is+cR0DYbj/KWP6ALVNbWPpqA/qPLoOuppJN07humpA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.46.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.46.0.tgz",
@@ -4006,6 +4069,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-select": {
@@ -4215,6 +4288,16 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.0.tgz",
+      "integrity": "sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -4556,6 +4639,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -4583,6 +4677,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -4914,6 +5014,20 @@
         "react-is": "^16.7.0"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4949,6 +5063,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -5133,6 +5253,23 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.3.tgz",
+      "integrity": "sha512-eURjAyz5iX1H8BOYAfzvdPfIKK53V7mCpBTe7Kb16PaM8JSXEcUQNBQaiWMI8wY5RvNOPj4GccMjTlfwRBd+oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.9",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.2.4",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/keyv": {
@@ -5504,6 +5641,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5592,6 +5735,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5852,6 +6002,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -6058,6 +6218,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regexpu-core": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.4.0.tgz",
@@ -6131,6 +6298,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rollup": {
@@ -6307,6 +6484,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
       }
     },
     "node_modules/string-width": {
@@ -6490,6 +6677,16 @@
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
       "license": "MIT"
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/svg.draggable.js": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/svg.draggable.js/-/svg.draggable.js-2.2.2.tgz",
@@ -6658,6 +6855,16 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/thenify": {
@@ -6863,6 +7070,16 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/vite": {
       "version": "6.4.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "flowbite-react": "^0.10.2",
     "formik": "^2.4.5",
     "formik-mui": "^5.0.0-alpha.0",
+    "jspdf": "^3.0.3",
     "lodash": "^4.17.21",
     "prop-types": "^15.7.2",
     "react": "^18.2.0",

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -40,12 +40,13 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
           .single();
         setProfile(profileData);
 
-        const { data: docenteData } = await supabase
+        const { data: docenteData, error: docenteErr } = await supabase
           .from('Eventos')
           .select('docente_id')
           .eq('docente_id', session.user.id)
-          .single();
-        setIsDocente(!!docenteData);
+          .maybeSingle();
+        // maybeSingle evita 406 cuando no hay filas; si no hay match, no es docente
+        setIsDocente(!!docenteData && !docenteErr);
       }
       setLoading(false);
     };

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -13,6 +13,7 @@ const UserManagement = Loadable(lazy(() => import("../views/Usuarios/UserManagem
 const CreateUserPage = Loadable(lazy(() => import("../views/Usuarios/CreateUserPage")));
 const Catalogo = Loadable(lazy(() => import('../views/catalogo/Catalogo')));
 const EventoDetalle = Loadable(lazy(() => import('../views/eventoDetalle/EventoDetalle')));
+const InscripcionWizard = Loadable(lazy(() => import('../views/Matricula/InscripcionWizard')));
 
 const Dashboard = Loadable(lazy(() => import('../views/dashboards/Dashboard')));
 const MiPerfil = Loadable(lazy(() => import('../views/perfil/MiPerfil')));
@@ -42,6 +43,7 @@ const Router = [
           { path: '/', element: <Dashboard /> },
           { path: '/catalogo', exact: true, element: <Catalogo /> },
           { path: '/evento/:id', exact: true, element: <EventoDetalle /> },
+          { path: '/evento/:id/inscripcion', exact: true, element: <InscripcionWizard /> },
           { path: '/ui/form', exact: true, element: <Form/> },
           { path: '/eventos/crear', exact: true, element: <CreateEvent/> },
           { path: '/eventos/listar', exact: true, element: <ListEvents/> },

--- a/src/views/Matricula/InscripcionWizard.tsx
+++ b/src/views/Matricula/InscripcionWizard.tsx
@@ -1,0 +1,522 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Alert, Badge, Button, Card, FileInput, Progress, Spinner, Timeline, Tooltip } from 'flowbite-react';
+import { supabase } from '../../utils/supabaseClient';
+import { useUser } from '../../contexts/UserContext';
+import { Evento } from '../../types/eventos';
+import { HiCheckCircle, HiCloudUpload, HiCreditCard, HiDocumentText, HiExclamation, HiInformationCircle, HiReceiptRefund } from 'react-icons/hi';
+import jsPDF from 'jspdf';
+
+type Requisito = {
+  id: number;
+  evento_id: number;
+  descripcion: string;
+  tipo_requisito?: string;
+};
+
+type Inscripcion = {
+  id: number;
+  usuario_id: string;
+  evento_id: number;
+  estado: string; // enum en BD
+  fecha_inscripcion?: string; // para recibo
+};
+
+type Pago = {
+  id: number;
+  inscripcion_id: number;
+  comprobante_url: string | null;
+  estado: string; // enum en BD
+};
+
+// Config: nombres de buckets de Storage (por defecto usamos 'eventos' que ya existe)
+// Puedes definir en .env: VITE_STORAGE_BUCKET_INSCRIPCIONES y VITE_STORAGE_BUCKET_PAGOS si quieres buckets separados
+const BUCKET_REQUISITOS = (import.meta.env.VITE_STORAGE_BUCKET_INSCRIPCIONES as string) || 'eventos';
+const BUCKET_PAGOS = (import.meta.env.VITE_STORAGE_BUCKET_PAGOS as string) || 'eventos';
+
+const InscripcionWizard: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { user, profile, loading: loadingUser } = useUser();
+
+  const [evento, setEvento] = useState<Evento | null>(null);
+  const [requisitos, setRequisitos] = useState<Requisito[]>([]);
+  const [inscripcion, setInscripcion] = useState<Inscripcion | null>(null);
+  const [pago, setPago] = useState<Pago | null>(null);
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [uploadingReq, setUploadingReq] = useState<Record<number, boolean>>({});
+  const [subidosReq, setSubidosReq] = useState<Record<number, string>>({}); // requisitoId -> url
+  const [uploadingPago, setUploadingPago] = useState(false);
+
+  const isPaid = !!evento?.es_pagado;
+  const paymentApproved = isPaid && (pago?.estado === 'aprobado');
+
+  const progressPct = useMemo(() => {
+    const total = requisitos.length + (isPaid ? 1 : 0);
+    if (total === 0) return 100;
+    const cumplidos = Object.keys(subidosReq).length + (pago?.comprobante_url ? 1 : 0);
+    return Math.min(100, Math.round((cumplidos / total) * 100));
+  }, [requisitos.length, subidosReq, pago, isPaid]);
+
+  useEffect(() => {
+    const bootstrap = async () => {
+      try {
+        if (!id || isNaN(Number(id))) throw new Error('Evento no válido');
+        if (loadingUser) return; // esperar sesión
+        if (!user) {
+          navigate('/auth/login');
+          return;
+        }
+
+        // 1) Cargar evento
+        const { data: eventoData, error: evErr } = await supabase
+          .from('Eventos')
+          .select('*')
+          .eq('id', id)
+          .single();
+        if (evErr) throw evErr;
+        setEvento(eventoData as Evento);
+
+        // 2) Cargar requisitos del evento
+        const { data: reqData, error: reqErr } = await supabase
+          .from('requisitos')
+          .select('*')
+          .eq('evento_id', id);
+        if (reqErr) throw reqErr;
+  const reqs = (reqData || []) as Requisito[];
+  setRequisitos(reqs);
+
+        // 3) Asegurar que exista la inscripción
+        const { data: inscrExist } = await supabase
+          .from('inscripciones')
+          .select('*')
+          .eq('usuario_id', user.id)
+          .eq('evento_id', id)
+          .maybeSingle();
+
+        let insc = inscrExist as Inscripcion | null;
+        if (!insc) {
+          const { data: inscInsert, error: inscErr } = await supabase
+            .from('inscripciones')
+            .insert({ usuario_id: user.id, evento_id: Number(id) })
+            .select()
+            .single();
+          if (inscErr) throw inscErr;
+          insc = inscInsert as Inscripcion;
+        }
+        setInscripcion(insc);
+
+        // 4) Cargar requisitos ya presentados
+        if (insc) {
+          const { data: reqPres } = await supabase
+            .from('inscripcion_requisitos_presentados')
+            .select('requisito_id, archivo_url')
+            .eq('inscripcion_id', insc.id);
+          const map: Record<number, string> = {};
+          (reqPres || []).forEach((r: any) => { map[r.requisito_id] = r.archivo_url; });
+          setSubidosReq(map);
+
+          // 5) Cargar pago si existe
+          const { data: pagoData } = await supabase
+            .from('pagos')
+            .select('*')
+            .eq('inscripcion_id', insc.id)
+            .maybeSingle();
+          const pagoRow = (pagoData as Pago) || null;
+          setPago(pagoRow);
+
+          // Actualizar estado si NO hay requisitos
+          if ((reqs?.length || 0) === 0) {
+            await updateInscripcionEstadoNoDocs(insc, pagoRow, eventoData as Evento);
+          }
+        }
+      } catch (e: any) {
+        setError(e.message || 'Error al iniciar inscripción');
+      } finally {
+        setLoading(false);
+      }
+    };
+    bootstrap();
+  }, [id, user, loadingUser, navigate]);
+
+  const updateInscripcionEstadoNoDocs = async (
+    insc: Inscripcion | null,
+    p: Pago | null,
+    ev: Evento | null
+  ) => {
+    try {
+      if (!insc || !ev) return;
+      if (requisitos.length > 0) return; // Solo aplica cuando no hay requisitos
+
+      let desired: string;
+      if (ev.es_pagado) {
+        const hasPaidEvidence = !!(p && (p.comprobante_url || p.estado === 'aprobado'));
+        desired = hasPaidEvidence ? 'pendiente_revision' : 'pendiente_pago';
+      } else {
+        desired = 'pendiente_revision';
+      }
+
+      if (insc.estado !== desired) {
+        const { error } = await supabase
+          .from('inscripciones')
+          .update({ estado: desired })
+          .eq('id', insc.id);
+        if (!error) setInscripcion({ ...insc, estado: desired });
+      }
+    } catch (e) {
+      // Silencioso; no bloquear flujo por estado
+    }
+  };
+
+  const handleUploadRequisito = async (requisito: Requisito, file?: File | null) => {
+    if (!file || !inscripcion) return;
+    setUploadingReq(prev => ({ ...prev, [requisito.id]: true }));
+    try {
+      const ext = file.name.split('.').pop();
+      const path = `${inscripcion.evento_id}/${inscripcion.usuario_id}/requisito_${requisito.id}_${Date.now()}.${ext}`;
+      const { error: upErr } = await supabase.storage
+        .from(BUCKET_REQUISITOS)
+        .upload(path, file, { upsert: true, contentType: file.type || 'application/octet-stream' });
+      if (upErr) throw upErr;
+      const { data: pub } = supabase.storage.from(BUCKET_REQUISITOS).getPublicUrl(path);
+      const archivo_url = pub.publicUrl;
+
+      // Insertar o actualizar registro
+      const { data: existente } = await supabase
+        .from('inscripcion_requisitos_presentados')
+        .select('id')
+        .eq('inscripcion_id', inscripcion.id)
+        .eq('requisito_id', requisito.id)
+        .maybeSingle();
+
+      if (existente?.id) {
+        const { error: updErr } = await supabase
+          .from('inscripcion_requisitos_presentados')
+          .update({ archivo_url, estado: 'pendiente' })
+          .eq('id', existente.id);
+        if (updErr) throw updErr;
+      } else {
+        const { error: insErr } = await supabase
+          .from('inscripcion_requisitos_presentados')
+          .insert({ inscripcion_id: inscripcion.id, requisito_id: requisito.id, archivo_url, estado: 'pendiente' });
+        if (insErr) throw insErr;
+      }
+
+      setSubidosReq(prev => ({ ...prev, [requisito.id]: archivo_url }));
+    } catch (e: any) {
+      setError(e.message || 'Error al subir requisito');
+    } finally {
+      setUploadingReq(prev => ({ ...prev, [requisito.id]: false }));
+    }
+  };
+
+  const handleUploadComprobante = async (file?: File | null) => {
+    if (!file || !inscripcion) return;
+    if (paymentApproved) return; // No permitir más cargas si ya está aprobado (simulado o real)
+    setUploadingPago(true);
+    try {
+      const ext = file.name.split('.').pop();
+      const path = `${inscripcion.id}/comprobante_${Date.now()}.${ext}`;
+      const { error: upErr } = await supabase.storage
+        .from(BUCKET_PAGOS)
+        .upload(path, file, { upsert: true, contentType: file.type || 'application/octet-stream' });
+      if (upErr) throw upErr;
+      const { data: pub } = supabase.storage.from(BUCKET_PAGOS).getPublicUrl(path);
+      const comprobante_url = pub.publicUrl;
+
+      if (pago?.id) {
+        const { error: updErr } = await supabase
+          .from('pagos')
+          .update({ comprobante_url, fecha_carga_comprobante: new Date().toISOString(), estado: 'pendiente' })
+          .eq('id', pago.id);
+        if (updErr) throw updErr;
+        const updatedPago = { ...pago, comprobante_url, estado: 'pendiente' } as Pago;
+        setPago(updatedPago);
+        // Si no hay requisitos, mover estado a pendiente_revision (se pagó, en revisión)
+        if (requisitos.length === 0 && evento) {
+          await updateInscripcionEstadoNoDocs(inscripcion, updatedPago, evento);
+        }
+      } else {
+        const { data: pagoIns, error: insErr } = await supabase
+          .from('pagos')
+          .insert({ inscripcion_id: inscripcion.id, comprobante_url, estado: 'pendiente', fecha_carga_comprobante: new Date().toISOString() })
+          .select('*')
+          .single();
+        if (insErr) throw insErr;
+        const newPago = pagoIns as Pago;
+        setPago(newPago);
+        if (requisitos.length === 0 && evento) {
+          await updateInscripcionEstadoNoDocs(inscripcion, newPago, evento);
+        }
+      }
+    } catch (e: any) {
+      setError(e.message || 'Error al subir comprobante');
+    } finally {
+      setUploadingPago(false);
+    }
+  };
+
+  const handleSimulatedCardPayment = async () => {
+    if (!inscripcion) return;
+    if (paymentApproved) return; // evitar re-pago
+    try {
+      // Marca el pago como aprobado (simulado)
+      if (pago?.id) {
+        const { error } = await supabase
+          .from('pagos')
+          .update({ estado: 'aprobado', fecha_revision: new Date().toISOString() })
+          .eq('id', pago.id);
+        if (error) throw error;
+        const updatedPago = { ...pago, estado: 'aprobado' } as Pago;
+        setPago(updatedPago);
+        if (requisitos.length === 0 && evento) {
+          await updateInscripcionEstadoNoDocs(inscripcion, updatedPago, evento);
+        }
+      } else {
+        const { data, error } = await supabase
+          .from('pagos')
+          .insert({ inscripcion_id: inscripcion.id, estado: 'aprobado', fecha_revision: new Date().toISOString() })
+          .select('*')
+          .single();
+        if (error) throw error;
+        const newPago = data as Pago;
+        setPago(newPago);
+        if (requisitos.length === 0 && evento) {
+          await updateInscripcionEstadoNoDocs(inscripcion, newPago, evento);
+        }
+      }
+    } catch (e: any) {
+      setError(e.message || 'No se pudo simular el pago');
+    }
+  };
+
+  const sanitizeFileName = (s: string) => s.replace(/[^a-zA-Z0-9_\- ]/g, '').replace(/\s+/g, ' ').trim().replace(/\s/g, '_');
+
+  const loadImageAsDataUrl = async (url: string): Promise<string | null> => {
+    try {
+      const res = await fetch(url, { mode: 'cors' });
+      const blob = await res.blob();
+      return await new Promise((resolve) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as string);
+        reader.onerror = () => resolve(null);
+        reader.readAsDataURL(blob);
+      });
+    } catch {
+      return null;
+    }
+  };
+
+  const generateReceiptPdf = async () => {
+    if (!evento || !inscripcion) return;
+
+    const doc = new jsPDF({ unit: 'mm', format: 'a4' });
+    const pageWidth = doc.internal.pageSize.getWidth();
+
+    // Encabezado
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(18);
+    doc.text('Comprobante de Registro', pageWidth / 2, 20, { align: 'center' });
+
+    // Imagen del curso si existe
+    let y = 30;
+    if (evento.imagen_url) {
+      const dataUrl = await loadImageAsDataUrl(evento.imagen_url);
+      if (dataUrl) {
+        const imgWidth = 60;
+        const imgHeight = 35; // aproximado
+        doc.addImage(dataUrl, 'JPEG', pageWidth - imgWidth - 15, y, imgWidth, imgHeight);
+      }
+    }
+
+    // Datos principales
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(12);
+    const lines = [
+      `N° de Registro: ${inscripcion.id}`,
+      `Curso/Evento: ${evento.nombre}`,
+      `Fecha de inicio: ${evento.fecha_inicio_evento ? new Date(evento.fecha_inicio_evento).toLocaleString('es-EC') : 'No especificada'}`,
+      `Fecha de inscripción: ${inscripcion.fecha_inscripcion ? new Date(inscripcion.fecha_inscripcion).toLocaleString('es-EC') : 'No especificada'}`,
+      `Participante: ${profile ? `${profile.nombre1} ${profile.apellido1}` : (user?.email || '')}`,
+      user?.email ? `Email: ${user.email}` : '',
+      evento.es_pagado ? `Tipo: Pagado  |  Monto: $${evento.costo ?? 0}` : 'Tipo: Gratuito'
+    ].filter(Boolean) as string[];
+
+    y += 5;
+    lines.forEach((t) => {
+      doc.text(t, 15, y);
+      y += 8;
+    });
+
+    // Pie
+    doc.setFontSize(10);
+    doc.text('Este documento es válido como comprobante de registro.', 15, 285);
+
+    const fileName = `${inscripcion.id}_${sanitizeFileName(evento.nombre)}.pdf`;
+    doc.save(fileName);
+  };
+
+  if (loading || loadingUser) {
+    return (
+      <div className="flex justify-center items-center h-[60vh]">
+        <Spinner size="xl" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="container mx-auto p-4">
+        <Alert color="failure" icon={HiInformationCircle}>{error}</Alert>
+      </div>
+    );
+  }
+
+  if (!evento || !inscripcion) return null;
+
+  const requisitosPendientes = requisitos.filter(r => !subidosReq[r.id]);
+
+  return (
+    <div className="container mx-auto p-4">
+      <Card>
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-semibold">Inscripción a: {evento.nombre}</h1>
+            <p className="text-sm text-gray-600">ID Inscripción: {inscripcion.id}</p>
+          </div>
+          <Badge color={isPaid ? 'warning' : 'success'}>{isPaid ? `Pago: $${evento.costo ?? 0}` : 'Gratuito'}</Badge>
+        </div>
+
+        <div className="mt-4">
+          <Progress progress={progressPct} labelProgress color={progressPct === 100 ? 'green' : 'blue'} />
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-6">
+          <Card>
+            <div className="flex items-center gap-2 mb-2">
+              <HiDocumentText />
+              <h2 className="text-lg font-semibold">Paso 1: Subir documentos</h2>
+            </div>
+            {requisitos.length === 0 && (
+              <Alert color="info">Este evento no requiere documentos adicionales.</Alert>
+            )}
+            <div className="space-y-4">
+              {requisitos.map((req) => (
+                <div key={req.id} className="border rounded p-3">
+                  <div className="flex items-center justify-between mb-2">
+                    <p className="font-medium">{req.descripcion}</p>
+                    {subidosReq[req.id] ? (
+                      <Badge color="success" icon={HiCheckCircle}>Subido</Badge>
+                    ) : (
+                      <Badge color="gray">Pendiente</Badge>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <FileInput onChange={(e) => handleUploadRequisito(req, e.target.files?.[0])} />
+                    <Button
+                      color="light"
+                      size="sm"
+                      disabled={uploadingReq[req.id]}
+                      onClick={() => {
+                        // Nada: se sube onChange
+                      }}
+                    >
+                      <HiCloudUpload className="mr-1" /> {uploadingReq[req.id] ? 'Subiendo...' : 'Subir'}
+                    </Button>
+                    {subidosReq[req.id] && (
+                      <a className="text-blue-600 underline" href={subidosReq[req.id]} target="_blank" rel="noreferrer">Ver archivo</a>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+            {requisitosPendientes.length > 0 && (
+              <Alert color="warning" className="mt-3" icon={HiExclamation}>
+                Faltan {requisitosPendientes.length} documento(s) por subir.
+              </Alert>
+            )}
+          </Card>
+
+          <Card>
+            <div className="flex items-center gap-2 mb-2">
+              <HiReceiptRefund />
+              <h2 className="text-lg font-semibold">Paso 2: Matriculación</h2>
+            </div>
+            {!isPaid ? (
+              <div className="space-y-3">
+                <p>El curso/evento es gratuito. Verifica tus datos antes de confirmar tu registro.</p>
+                <div className="text-sm text-gray-700 border rounded p-3">
+                  <p><span className="font-medium">Participante:</span> {profile ? `${profile.nombre1} ${profile.apellido1}` : user?.email}</p>
+                  <p><span className="font-medium">Evento:</span> {evento.nombre}</p>
+                </div>
+                <Tooltip content="Descarga tu comprobante en PDF" placement="top">
+                  <Button color="success" onClick={generateReceiptPdf}>
+                    Generar comprobante de registro
+                  </Button>
+                </Tooltip>
+                <Alert color="info">Tu inscripción queda registrada. La confirmación puede estar sujeta a revisión.</Alert>
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <p>Este evento requiere pago. Sube tu comprobante o usa el simulador de pago.</p>
+                  <div className="flex items-center gap-3">
+                    <FileInput onChange={(e) => handleUploadComprobante(e.target.files?.[0])} disabled={paymentApproved} />
+                    <Button color="light" size="sm" onClick={() => { /* subida onChange */ }} disabled={uploadingPago || paymentApproved}>
+                      <HiCloudUpload className="mr-1" /> {uploadingPago ? 'Subiendo...' : 'Subir comprobante'}
+                    </Button>
+                  </div>
+                  {pago?.comprobante_url && (
+                    <Alert color="success">Comprobante cargado. Estado de pago: <b className="capitalize">{pago.estado}</b> — <a className="underline" href={pago.comprobante_url || ''} target="_blank" rel="noreferrer">Ver archivo</a></Alert>
+                  )}
+                  <div className="flex items-center gap-2">
+                    <Button color="purple" onClick={handleSimulatedCardPayment} disabled={paymentApproved}>
+                      <HiCreditCard className="mr-1" /> {paymentApproved ? 'Pago aprobado' : 'Pagar con tarjeta (simulado)'}
+                    </Button>
+                    <small className="text-gray-500">{paymentApproved ? 'El pago está aprobado; no es posible volver a pagar.' : 'Opcional para pruebas — marca el pago como aprobado'}</small>
+                  </div>
+                <div>
+                  <Button color="success" onClick={generateReceiptPdf}>
+                    Generar comprobante de registro
+                  </Button>
+                </div>
+              </div>
+            )}
+          </Card>
+        </div>
+
+        <div className="mt-6">
+          <Timeline>
+            <Timeline.Item>
+              <Timeline.Point icon={HiDocumentText} />
+              <Timeline.Content>
+                <Timeline.Time>Paso 1</Timeline.Time>
+                <Timeline.Title>Sube tus documentos</Timeline.Title>
+                <Timeline.Body>Requisitos obligatorios si el evento los define. Estado actual: {Object.keys(subidosReq).length}/{requisitos.length} subidos.</Timeline.Body>
+              </Timeline.Content>
+            </Timeline.Item>
+            <Timeline.Item>
+              <Timeline.Point icon={HiReceiptRefund} />
+              <Timeline.Content>
+                <Timeline.Time>Paso 2</Timeline.Time>
+                <Timeline.Title>{isPaid ? 'Pago y comprobante' : 'Confirmación de registro'}</Timeline.Title>
+                <Timeline.Body>
+                  {isPaid ? 'Sube un comprobante o usa el simulador para completar el proceso.' : 'Genera y guarda tu comprobante de registro.'}
+                </Timeline.Body>
+              </Timeline.Content>
+            </Timeline.Item>
+          </Timeline>
+        </div>
+
+        <div className="mt-6 flex justify-between">
+          <Button color="gray" onClick={() => navigate(-1)}>Volver</Button>
+          <Button color="success" onClick={() => navigate(`/evento/${evento.id}`)}>Ir al detalle</Button>
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+export default InscripcionWizard;

--- a/src/views/eventoDetalle/EventoDetalle.tsx
+++ b/src/views/eventoDetalle/EventoDetalle.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { supabase } from '../../utils/supabaseClient';
 import { Evento } from '../../types/eventos';
 import { Alert, Spinner, Card, Badge, Button } from 'flowbite-react';
@@ -7,6 +7,7 @@ import { HiCalendar, HiOutlineClock, HiUser, HiIdentification, HiOutlineSparkles
 
 const EventoDetalle: React.FC = () => {
   const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
   const [evento, setEvento] = useState<Evento | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
@@ -152,6 +153,7 @@ const EventoDetalle: React.FC = () => {
             color={isRegistrationOpen ? 'success' : 'gray'} 
             disabled={!isRegistrationOpen}
             size="lg"
+            onClick={() => navigate(`/evento/${evento.id}/inscripcion`)}
           >
             {registrationMessage}
           </Button>


### PR DESCRIPTION

### 📝 Descripción General

Este PR introduce el flujo completo de Matrícula e Inscripción en dos pasos, alineado con el esquema de BD existente (inscripciones, requisitos, pagos) y con integración de almacenamiento en Supabase Storage. Permite:

- Paso 1: subir documentos/requisitos por evento (cuando apliquen).
- Paso 2: matriculación diferenciada para eventos gratuitos vs. de pago:
  - Gratuitos: verificación ligera de datos y generación de comprobante de registro en PDF.
  - De pago: subida de comprobante o “pago simulado” con bloqueo de repetición y recibo PDF.

Además, automatiza transiciones de estado cuando el evento no requiere documentos, agrega un comprobante PDF con nombre estandarizado “{inscripcionId}_{Curso}.pdf” e integra una ruta dedicada desde el detalle del evento. Se mejora la robustez del contexto de usuario para evitar errores 406 al validar si un usuario es docente.

---

### 📜 Resumen de Cambios

#### ✨ Funcionalidad Principal
- Asistente de Inscripción (2 pasos)
  - Ruta nueva: `/evento/:id/inscripcion` con UI de pasos, barra de progreso y timeline.
  - Paso 1: subida de requisitos por evento a Supabase Storage (registro en `inscripcion_requisitos_presentados`), con estado por requisito y vista de archivo subido.
  - Paso 2:
    - Eventos gratuitos: verificación visible de datos del usuario y generación de comprobante PDF.
    - Eventos de pago: subida de comprobante (Storage) o pago simulado con tarjeta; se deshabilitan controles tras aprobar el pago (evita re-pago).
- Comprobante de registro en PDF
  - Generado con jsPDF, nombre: `inscripcionId_Curso.pdf`.
  - Contiene: nombre del curso, imagen (si existe), fecha de inicio del evento, fecha de inscripción, datos del estudiante (nombre/email).
- Estados automáticos (cuando no hay requisitos)
  - Evento gratuito: `inscripciones.estado → pendiente_revision`.
  - Evento de pago: `inscripciones.estado → pendiente_pago`, y tras comprobante o pago simulado: `pendiente_revision`.
- Navegación desde detalle del evento
  - Botón “Inscribirse ahora” lleva al asistente y respeta el período de inscripciones.

Archivos clave:
- New: InscripcionWizard.tsx (asistente completo).
- Update: Router.tsx (ruta nueva).
- Update: EventoDetalle.tsx (acción del botón).
- Update: UserContext.tsx (consulta docente con `.maybeSingle()` para evitar 406).
- Dependencies: añade `jspdf`.

#### 🛡️ Seguridad y Control de Acceso (RBAC)
- Robustez en `UserContext`: reemplazo de `.single()` por `.maybeSingle()` al consultar si el usuario es docente para evitar 406 Not Acceptable cuando no hay filas.
- Recomendación de Policies RLS (para aplicar en Supabase):
  - `inscripciones`: insert/select/update propias.
  - `inscripcion_requisitos_presentados`: insert/select/update condicionados a que la inscripción pertenezca al usuario.
  - `pagos`: insert/select/update condicionados a su inscripción.
  - `storage.objects` (bucket): permitir insert/select para el bucket usado (por defecto ‘eventos’). Si mantienes privado, usar URLs firmadas; si público, `getPublicUrl()` funciona como está.

#### 🔧 Mejoras Técnicas y Arquitectura
- Storage configurable por .env:
  - Usa por defecto el bucket existente `eventos` para evitar “bucket not found”.
  - Variables opcionales: `VITE_STORAGE_BUCKET_INSCRIPCIONES` y `VITE_STORAGE_BUCKET_PAGOS`.
  - Establece `contentType` en uploads para evitar errores 400 de Storage.
- Deshabilita controles de pago al aprobar (simulado), con guard en handlers y UI.

---

### ✅ ¿Cómo se ha probado esto?

Pre-requisitos:
- Tener `VITE_SUPABASE_URL` y `VITE_SUPABASE_ANON_KEY` configurados.
- En Supabase: policies RLS aplicadas para `inscripciones`, `inscripcion_requisitos_presentados`, `pagos` y `storage.objects`. Bucket ‘eventos’ existente (o define los tuyos en .env y créalos).
- Usuario autenticado.

Pruebas manuales:
1. Inicia sesión.
2. Ve a `/evento/:id` con inscripciones abiertas y pulsa “Inscribirse ahora”.
3. Caso A (Evento gratuito sin requisitos):
   - Verifica datos del usuario.
   - Observa que `inscripciones.estado` pase a `pendiente_revision`.
   - Genera el PDF y confirma el nombre `inscripcionId_Curso.pdf`.
4. Caso B (Evento de pago sin requisitos):
   - Observa `inscripciones.estado` como `pendiente_pago`.
   - Sube un comprobante o usa “Pagar con tarjeta (simulado)”.
   - Verifica que tras el pago el estado sea `pendiente_revision`.
   - Confirma que los controles de pago quedan deshabilitados.
   - Genera el PDF y valida su contenido.
5. Caso C (Evento con requisitos):
   - Sube archivos de requisitos, revisa que se marquen como “Subido”, ver archivo y progreso.
   - (Pendiente siguiente mejora) Confirmar transición automática al completar todos los requisitos.
6. Revisa que el botón del detalle de evento lleve correctamente al asistente.

---

### 🖼️ Resultado Visual de la Funcionalidad

- Asistente de inscripción con pasos, barra de progreso y timeline. 
- Se agradecen capturas: 
  - Paso 1 con requisitos (Pendiente/Subido).
  - Paso 2 gratuito con datos del usuario y botón de comprobante.
  - Paso 2 de pago con controles deshabilitados tras aprobación.

---

### ☑️ Checklist del Contribuyente
- [x] Mi código sigue las guías de estilo de este proyecto.
- [x] He realizado una auto-revisión de mi propio código.
- [ ] Mis cambios no generan nuevas advertencias (warnings). 
  - Nota: existen warnings/errores previos fuera del alcance de este PR (variables no usadas y types faltantes en otras vistas). Puedo limpiarlos en un PR de mantenimiento.
- [x] (Si aplica) He actualizado la documentación correspondiente (instrucciones de buckets y RLS).

---

Notas y próximos pasos propuestos:
- Transición automática cuando SÍ hay requisitos y el usuario completa todos:
  - Pagado → `pendiente_pago`
  - Gratuito → `pendiente_revision`
- Validación server-side de audiencia/carrera antes de confirmar matrícula (necesitamos la fuente de la carrera del usuario).
- Número de orden legible (p. ej., `ORD-2025-000123`) guardado en `pagos` y mostrado en UI/PDF.
- Endurecer Storage (privado + URLs firmadas) si los documentos deben ser confidenciales.